### PR TITLE
Add Authors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ Have an idea? [Open an issue](https://github.com/goflowspace/goflow/issues/new) 
 
 Go Flow was created by [Artem Slizhik](https://www.linkedin.com/in/temaslizhik/) and [Egor Lyskov](https://www.linkedin.com/in/egor-lyskov/), with invaluable financial support from [Dmitrii Kobzar](https://www.linkedin.com/in/dmitriy-kobzar-01a3b266/) and [Ilya Saunkin](https://www.linkedin.com/in/ilya-saunkin-5a750459/).
 
+Special thanks to the indie gamedev community — over 35 interviews with game developers, narrative designers, and writers helped shape Go Flow into what it is today.
+
 ## License
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE).

--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ Have an idea? [Open an issue](https://github.com/goflowspace/goflow/issues/new) 
 - [Telegram Community](https://t.me/flow_community_chat) — community chat
 - [GitHub Issues](https://github.com/goflowspace/goflow/issues) — bug reports and feature requests
 
+## Authors
+
+Go Flow was created by [Artem Slizhik](https://www.linkedin.com/in/temaslizhik/) and [Egor Lyskov](https://www.linkedin.com/in/egor-lyskov/), with invaluable financial support from [Dmitrii Kobzar](https://www.linkedin.com/in/dmitriy-kobzar-01a3b266/) and [Ilya Saunkin](https://www.linkedin.com/in/ilya-saunkin-5a750459/).
+
 ## License
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE).


### PR DESCRIPTION
## Summary

- Add **Authors** section before License crediting the creators and financial backers of Go Flow

## Test plan

- [ ] Verify all LinkedIn links resolve correctly
- [ ] Confirm section renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)